### PR TITLE
feat: add wezterm ssh_domain for RTX4080 mux

### DIFF
--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -153,6 +153,17 @@ if wezterm.target_triple == "x86_64-pc-windows-msvc" then
 else
 	table.insert(config.launch_menu, { label = "bash", args = { "bash", "-l" } })
 	table.insert(config.launch_menu, { label = "fish", args = { "fish", "-l" } })
+
+	if wezterm.target_triple:find("darwin") then
+		config.ssh_domains = {
+			{
+				name = "rtx4080mux",
+				remote_address = "100.113.211.113", -- Tailscale IP (RTX4080)
+				username = "ryu19",
+				multiplexing = "WezTerm",
+			},
+		}
+	end
 end
 
 -- 背景画像設定（画像が存在する場合のみ）


### PR DESCRIPTION
## Summary
- Adds a `ssh_domains` entry (macOS only) so `wezterm connect rtx4080mux` can attach to `wezterm-mux-server` running on the RTX4080 Windows SSH host over Tailscale
- Terminal sessions (including long-running CLI agents) survive laptop sleep/network drops since the mux server keeps running independently of the SSH connection

## Test plan
- [x] Confirmed `wezterm-mux-server.exe` runs standalone on the Windows host and stays alive after its parent process exits
- [ ] Confirm `wezterm connect rtx4080mux` from macOS attaches successfully
- [ ] Confirm a pane survives laptop sleep and reattaches with state intact